### PR TITLE
Set isolatedModules to true for ESBuild support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "noEmit": false,
     "noLib": false,
     "baseUrl": "source",
+    "isolatedModules": true,
+    "esModuleInterop": true,
     // "rootDir": "source",
     "outDir": "build/dist",
     "declarationDir": "build/dist",


### PR DESCRIPTION
ESBuild requires isolatedModules TypeScript configuration option to be enabled.